### PR TITLE
Allow configuring timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY apolpi.py boot.sh ./
 RUN chmod +x boot.sh
 
 ENV FLASK_APP apolpi.py
+ENV TIMEOUT 30
 EXPOSE 80
 
 ENTRYPOINT ["/apolpi/boot.sh"]

--- a/apolpi.py
+++ b/apolpi.py
@@ -9,8 +9,10 @@ from flask_sqlalchemy import SQLAlchemy
 
 global CACHED_RESULT
 global CACHED_TIME
+global TIMEOUT
 CACHED_RESULT = None
 CACHED_TIME = 0
+TIMEOUT = int(os.environ.get('TIMEOUT', 30))
 
 app = Flask(__name__)
 
@@ -113,7 +115,7 @@ def doit():
     global CACHED_TIME
     global CACHED_RESULT
     now = time.time()
-    if now - CACHED_TIME > 30:
+    if now - CACHED_TIME > TIMEOUT:
         CACHED_RESULT = _fetch()
         CACHED_TIME = now
 


### PR DESCRIPTION
@jasonjgill is having issues creating an organism, I suspect due to failing read-after-write. Since apollo uses POSTs for both because they don't use a proper authentication header and GET for queries, we can't expire the cache that way. Thus we are stuck manually changing the timeout (I'm not entirely sure why the tools don't experience this, but CPT could be using some custom script triggering this.)