### PR TITLE
add a GUNICORN_TIMEOUT

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN chmod +x boot.sh
 
 ENV FLASK_APP apolpi.py
 ENV TIMEOUT 30
+ENV GUNICORN_TIMEOUT 30
 EXPOSE 80
 
 ENTRYPOINT ["/apolpi/boot.sh"]

--- a/boot.sh
+++ b/boot.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec gunicorn -b :80 --access-logfile - --error-logfile - apolpi:app
+exec gunicorn -b :80 --access-logfile - --error-logfile - --timeout ${GUNICORN_TIMEOUT:-30} apolpi:app


### PR DESCRIPTION
I guess the whole purpose of this repo is that the API request is not that slow, but at least for debugging this is useful and I need to currently set this, otherwise my :unicorn: are killed :cry: 